### PR TITLE
feat: server-side sessions, SSE fixes, UNKNOWN RAG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,14 +55,15 @@ scripts/                    Shell helpers (docker-build-needed.sh)
 | `GET /healthz` | no | Liveness probe |
 | `GET /readyz` | no | 503 until informer synced |
 | `GET /metrics` | no | Prometheus |
-| `POST /api/session` | bearer | Exchange token for HTTP-only session cookie |
+| `POST /api/session` | bearer | Exchange token for random session-ID cookie (24h TTL) |
+| `DELETE /api/session` | no | Revoke own session, expire cookie |
 | `GET /api/dashboard` | bearer/session | Aggregated summary HTML partial |
 | `GET /workload/{ns}/{name}` | bearer/session | Detail table for one report |
 | `GET /api/events` | session | SSE stream ("refresh" on store changes) |
 
 Auth only active when `TRIVY_DASHBOARD_TOKEN` env var is set.
 
-**RAG logic**: Red = any CRITICAL/HIGH. Amber = any MEDIUM (no higher). Green = LOW only or clean.
+**RAG logic**: Red = any CRITICAL/HIGH. Amber = any MEDIUM or UNKNOWN (no higher). Green = LOW only or clean.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ RAG rules per workload:
 | Bucket | Condition |
 | ------ | --------- |
 | Red    | any `CRITICAL` or `HIGH` vuln |
-| Amber  | any `MEDIUM` vuln (no higher) |
+| Amber  | any `MEDIUM` or `UNKNOWN` vuln (no higher) |
 | Green  | only `LOW` or clean |
 
 The aggregate dashboard tile is Red if any workload is Red, Amber if any is
@@ -29,6 +29,7 @@ Amber, Green otherwise.
 | ------ | ---- | ---- | ----------- |
 | GET | `/` | — | Dashboard shell (no data; UI fetches `/api/dashboard`) |
 | POST | `/api/session` | bearer (if `TRIVY_DASHBOARD_TOKEN` set) | Browser session cookie setup |
+| DELETE | `/api/session` | — | Revoke own session and expire the cookie |
 | GET | `/api/dashboard` | bearer/session (if `TRIVY_DASHBOARD_TOKEN` set) | Summary HTML partial |
 | GET | `/workload/{namespace}/{report}` | bearer/session (if token set) | Detail page for one VulnerabilityReport |
 | GET | `/static/*` | — | Embedded CSS/JS |
@@ -44,9 +45,12 @@ Amber, Green otherwise.
 | `TRIVY_DASHBOARD_SECURE_COOKIES` | `false` | If `true`, always mark browser session cookies as `Secure`. Useful when the app runs behind TLS-terminating ingress. |
 | `KUBECONFIG` | `~/.kube/config` | Only used outside the cluster when in-cluster config isn't available |
 
-When `TRIVY_DASHBOARD_TOKEN` is set, browser requests first exchange the bearer
-token for an HTTP-only same-site session cookie at `POST /api/session`. The SSE
-stream uses that cookie so credentials are not placed in query strings.
+When `TRIVY_DASHBOARD_TOKEN` is set, the browser exchanges the bearer token at
+`POST /api/session` for a random server-minted session ID stored in an
+HTTP-only same-site cookie (24h TTL, in-memory — a pod restart signs everyone
+out). The token itself is used for that one request and never stored
+client-side. The SSE stream authenticates with the cookie so credentials are
+not placed in query strings.
 
 In production `TRIVY_DASHBOARD_TOKEN` comes from the `trivy-dashboard-auth`
 Secret, populated by ExternalSecrets.

--- a/internal/api/broker.go
+++ b/internal/api/broker.go
@@ -7,50 +7,80 @@ import (
 
 // Broker fans out store-change notifications to connected SSE clients.
 // Notifications are debounced — rapid changes coalesce into one event
-// after the debounce interval elapses with no new changes.
+// after the debounce interval elapses with no new changes, capped so a
+// continuous stream of changes cannot starve broadcasts forever.
 type Broker struct {
 	mu          sync.Mutex
 	subscribers map[chan struct{}]struct{}
 	debounce    time.Duration
+	maxWait     time.Duration
 	timer       *time.Timer
+	pending     time.Time
 	done        chan struct{}
 }
 
-// NewBroker creates a broker with the given debounce interval.
+// NewBroker creates a broker with the given debounce interval. A broadcast
+// is guaranteed within roughly 4x the debounce interval of the first
+// pending notification, even under continuous change.
 func NewBroker(debounce time.Duration) *Broker {
 	return &Broker{
 		subscribers: make(map[chan struct{}]struct{}),
 		debounce:    debounce,
+		maxWait:     4 * debounce,
 		done:        make(chan struct{}),
 	}
 }
 
 // Subscribe returns a channel that receives a value each time the
-// dashboard should refresh.
+// dashboard should refresh. After Shutdown the returned channel is
+// already closed.
 func (b *Broker) Subscribe() chan struct{} {
 	ch := make(chan struct{}, 1)
 	b.mu.Lock()
+	defer b.mu.Unlock()
+	select {
+	case <-b.done:
+		close(ch)
+		return ch
+	default:
+	}
 	b.subscribers[ch] = struct{}{}
-	b.mu.Unlock()
 	return ch
 }
 
-// Unsubscribe removes a subscriber and closes its channel.
+// Unsubscribe removes a subscriber and closes its channel. Safe to call
+// after Shutdown has already closed the channel.
 func (b *Broker) Unsubscribe(ch chan struct{}) {
 	b.mu.Lock()
-	delete(b.subscribers, ch)
-	b.mu.Unlock()
-	close(ch)
+	defer b.mu.Unlock()
+	if _, ok := b.subscribers[ch]; ok {
+		delete(b.subscribers, ch)
+		close(ch)
+	}
+}
+
+// SubscriberCount returns the number of connected subscribers.
+func (b *Broker) SubscriberCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.subscribers)
 }
 
 // Notify signals that the store changed. The actual broadcast is
-// debounced — if Notify is called again within the debounce window,
-// the timer resets.
+// debounced — if Notify is called again within the debounce window, the
+// timer resets, but once the oldest pending notification is maxWait old
+// the scheduled broadcast is left to fire.
 func (b *Broker) Notify() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.timer != nil {
+	now := time.Now()
+	if b.timer == nil {
+		b.pending = now
+	} else {
+		if now.Sub(b.pending) >= b.maxWait {
+			return
+		}
 		b.timer.Stop()
 	}
 	b.timer = time.AfterFunc(b.debounce, b.broadcast)
@@ -59,6 +89,8 @@ func (b *Broker) Notify() {
 func (b *Broker) broadcast() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	b.timer = nil
 
 	select {
 	case <-b.done:
@@ -74,12 +106,23 @@ func (b *Broker) broadcast() {
 	}
 }
 
-// Shutdown stops the broker and prevents further broadcasts.
+// Shutdown stops the broker, prevents further broadcasts, and closes all
+// subscriber channels so blocked SSE handlers unwind. Idempotent.
 func (b *Broker) Shutdown() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	select {
+	case <-b.done:
+		return
+	default:
+	}
 	close(b.done)
 	if b.timer != nil {
 		b.timer.Stop()
+		b.timer = nil
 	}
+	for ch := range b.subscribers {
+		close(ch)
+	}
+	b.subscribers = make(map[chan struct{}]struct{})
 }

--- a/internal/api/broker_test.go
+++ b/internal/api/broker_test.go
@@ -69,6 +69,96 @@ func TestBroker_UnsubscribeRemovesFromSet(t *testing.T) {
 	}
 }
 
+func TestBroker_MaxWaitUnderContinuousNotify(t *testing.T) {
+	b := NewBroker(50 * time.Millisecond)
+	defer b.Shutdown()
+
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-ch:
+			return
+		case <-deadline:
+			t.Fatal("no broadcast under continuous notifications — debounce starvation")
+		case <-ticker.C:
+			b.Notify()
+		}
+	}
+}
+
+func TestBroker_ShutdownClosesSubscribers(t *testing.T) {
+	b := NewBroker(10 * time.Millisecond)
+	ch := b.Subscribe()
+
+	b.Shutdown()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected closed channel, got value")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("subscriber channel not closed on shutdown")
+	}
+
+	b.Unsubscribe(ch) // must not panic on already-closed channel
+	b.Shutdown()      // idempotent
+}
+
+func TestBroker_ShutdownCancelsPendingBroadcast(t *testing.T) {
+	b := NewBroker(50 * time.Millisecond)
+	ch := b.Subscribe()
+
+	b.Notify()
+	b.Shutdown()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected closed channel, got broadcast after shutdown")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("subscriber channel not closed")
+	}
+}
+
+func TestBroker_SubscribeAfterShutdownReturnsClosedChannel(t *testing.T) {
+	b := NewBroker(10 * time.Millisecond)
+	b.Shutdown()
+
+	ch := b.Subscribe()
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected closed channel, got value")
+		}
+	default:
+		t.Fatal("channel from post-shutdown Subscribe should already be closed")
+	}
+}
+
+func TestBroker_SubscriberCount(t *testing.T) {
+	b := NewBroker(10 * time.Millisecond)
+	defer b.Shutdown()
+
+	if got := b.SubscriberCount(); got != 0 {
+		t.Fatalf("count = %d, want 0", got)
+	}
+	ch := b.Subscribe()
+	if got := b.SubscriberCount(); got != 1 {
+		t.Fatalf("count = %d, want 1", got)
+	}
+	b.Unsubscribe(ch)
+	if got := b.SubscriberCount(); got != 0 {
+		t.Fatalf("count = %d, want 0 after unsubscribe", got)
+	}
+}
+
 func TestBroker_MultipleSubscribers(t *testing.T) {
 	b := NewBroker(10 * time.Millisecond)
 	defer b.Shutdown()

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -6,17 +6,20 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
-	"strings"
+	"time"
 
 	"github.com/tobydoescode/trivy-dashboard/internal/auth"
 	"github.com/tobydoescode/trivy-dashboard/internal/kube"
 )
+
+var sseHeartbeatInterval = 30 * time.Second
 
 // Handler serves the dashboard HTML pages and SSE stream.
 type Handler struct {
 	store         *kube.Store
 	templates     *template.Template
 	broker        *Broker
+	sessions      *auth.SessionStore
 	authRequired  bool
 	secureCookies bool
 }
@@ -25,20 +28,18 @@ type Handler struct {
 type HandlerOptions struct {
 	AuthRequired  bool
 	SecureCookies bool
+	Sessions      *auth.SessionStore
 }
 
 // NewHandler creates a Handler with the given store, templates, and SSE broker.
-func NewHandler(store *kube.Store, templates *template.Template, broker *Broker, opts ...HandlerOptions) *Handler {
-	var opt HandlerOptions
-	if len(opts) > 0 {
-		opt = opts[0]
-	}
+func NewHandler(store *kube.Store, templates *template.Template, broker *Broker, opts HandlerOptions) *Handler {
 	return &Handler{
 		store:         store,
 		templates:     templates,
 		broker:        broker,
-		authRequired:  opt.AuthRequired,
-		secureCookies: opt.SecureCookies,
+		sessions:      opts.Sessions,
+		authRequired:  opts.AuthRequired,
+		secureCookies: opts.SecureCookies,
 	}
 }
 
@@ -58,19 +59,19 @@ func (h *Handler) Index(w http.ResponseWriter, _ *http.Request) {
 	h.renderTemplate(w, "index.html", struct{ AuthRequired bool }{h.authRequired})
 }
 
-// Session sets a browser session cookie after bearer authentication succeeds.
+// Session mints a random server-side session ID and sets it as an HTTP-only
+// cookie. Bearer authentication happens in middleware before this runs, so
+// the token itself never has to be stored client-side.
 func (h *Handler) Session(w http.ResponseWriter, r *http.Request) {
-	const prefix = "Bearer "
-	hdr := r.Header.Get("Authorization")
-	if !strings.HasPrefix(hdr, prefix) {
-		http.Error(w, "missing bearer token", http.StatusUnauthorized)
+	if h.sessions == nil {
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-
 	http.SetCookie(w, &http.Cookie{
 		Name:     auth.SessionCookieName,
-		Value:    strings.TrimPrefix(hdr, prefix),
+		Value:    h.sessions.Create(),
 		Path:     "/",
+		MaxAge:   int(h.sessions.TTL().Seconds()),
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
 		Secure:   h.secureCookies || r.TLS != nil,
@@ -83,6 +84,25 @@ func (h *Handler) SessionNoop(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// SignOut revokes the caller's session and expires the cookie.
+func (h *Handler) SignOut(w http.ResponseWriter, r *http.Request) {
+	if h.sessions != nil {
+		if cookie, err := r.Cookie(auth.SessionCookieName); err == nil {
+			h.sessions.Delete(cookie.Value)
+		}
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     auth.SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   h.secureCookies || r.TLS != nil,
+	})
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // DashboardContent renders the dashboard data partial (authenticated).
 func (h *Handler) DashboardContent(w http.ResponseWriter, _ *http.Request) {
 	h.renderTemplate(w, "dashboard.html", BuildDashboard(h.store.All()))
@@ -90,35 +110,29 @@ func (h *Handler) DashboardContent(w http.ResponseWriter, _ *http.Request) {
 
 // WorkloadDetail renders the detail page for a single workload.
 func (h *Handler) WorkloadDetail(w http.ResponseWriter, r *http.Request) {
-	namespace := r.PathValue("namespace")
-	reportName := r.PathValue("report")
-
-	dash := BuildDashboard(h.store.All())
-
-	var workload *WorkloadSummary
-	for i := range dash.Workloads {
-		if dash.Workloads[i].Namespace == namespace && dash.Workloads[i].ReportName == reportName {
-			workload = &dash.Workloads[i]
-			break
-		}
-	}
-
-	if workload == nil {
+	report, ok := h.store.Get(r.PathValue("namespace"), r.PathValue("report"))
+	if !ok {
 		http.NotFound(w, r)
 		return
 	}
-
-	h.renderTemplate(w, "workload-detail.html", workload)
+	ws := buildWorkloadSummary(report)
+	h.renderTemplate(w, "workload-detail.html", &ws)
 }
 
 // SSE streams server-sent events to the client. A "refresh" event is
-// sent whenever the vulnerability store changes.
+// sent whenever the vulnerability store changes; comment pings keep the
+// connection alive through proxies.
 func (h *Handler) SSE(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
+
+	// The server-wide WriteTimeout would sever the stream; SSE responses
+	// never complete, so clear the deadline for this response only.
+	rc := http.NewResponseController(w)
+	rc.SetWriteDeadline(time.Time{}) //nolint:errcheck // test recorders lack deadline support
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -130,10 +144,16 @@ func (h *Handler) SSE(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, ": connected\n\n") //nolint:errcheck // best-effort SSE write
 	flusher.Flush()
 
+	heartbeat := time.NewTicker(sseHeartbeatInterval)
+	defer heartbeat.Stop()
+
 	for {
 		select {
 		case <-r.Context().Done():
 			return
+		case <-heartbeat.C:
+			fmt.Fprintf(w, ": ping\n\n") //nolint:errcheck // best-effort SSE write
+			flusher.Flush()
 		case _, ok := <-ch:
 			if !ok {
 				return

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"html/template"
 	"net/http"
 	"net/http/httptest"
@@ -92,11 +93,11 @@ func TestIndex_AuthRequired(t *testing.T) {
 	}
 }
 
-func TestSession_SetsHttpOnlyCookie(t *testing.T) {
-	h := testHandler(t)
+func TestSession_SetsRandomSessionIDCookie(t *testing.T) {
+	sessions := auth.NewSessionStore(time.Hour)
+	h := testHandlerWithOptions(t, HandlerOptions{AuthRequired: true, Sessions: sessions})
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/session", nil)
-	req.Header.Set("Authorization", "Bearer secret")
 
 	h.Session(rec, req)
 
@@ -111,11 +112,14 @@ func TestSession_SetsHttpOnlyCookie(t *testing.T) {
 	if got.Name != auth.SessionCookieName {
 		t.Fatalf("cookie name = %q, want %q", got.Name, auth.SessionCookieName)
 	}
-	if got.Value != "secret" {
-		t.Fatalf("cookie value = %q, want secret", got.Value)
+	if !sessions.Valid(got.Value) {
+		t.Fatal("cookie value should be a live session ID")
 	}
 	if got.Path != "/" {
 		t.Fatalf("cookie path = %q, want /", got.Path)
+	}
+	if got.MaxAge != int(time.Hour.Seconds()) {
+		t.Fatalf("cookie MaxAge = %d, want %d", got.MaxAge, int(time.Hour.Seconds()))
 	}
 	if !got.HttpOnly {
 		t.Fatal("cookie should be HttpOnly")
@@ -126,10 +130,10 @@ func TestSession_SetsHttpOnlyCookie(t *testing.T) {
 }
 
 func TestSession_CanForceSecureCookieBehindProxy(t *testing.T) {
-	h := testHandlerWithOptions(t, HandlerOptions{AuthRequired: true, SecureCookies: true})
+	sessions := auth.NewSessionStore(time.Hour)
+	h := testHandlerWithOptions(t, HandlerOptions{AuthRequired: true, SecureCookies: true, Sessions: sessions})
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/session", nil)
-	req.Header.Set("Authorization", "Bearer secret")
 
 	h.Session(rec, req)
 
@@ -145,15 +149,104 @@ func TestSession_CanForceSecureCookieBehindProxy(t *testing.T) {
 	}
 }
 
-func TestSession_RejectsMissingBearerToken(t *testing.T) {
+func TestSession_MarksCookieSecureOverTLS(t *testing.T) {
+	sessions := auth.NewSessionStore(time.Hour)
+	h := testHandlerWithOptions(t, HandlerOptions{AuthRequired: true, Sessions: sessions})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/session", nil)
+	req.TLS = &tls.ConnectionState{}
+
+	h.Session(rec, req)
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("cookies = %d, want 1", len(cookies))
+	}
+	if !cookies[0].Secure {
+		t.Fatal("cookie should be Secure on a TLS request")
+	}
+}
+
+func TestSession_NilSessionStoreSetsNoCookie(t *testing.T) {
 	h := testHandler(t)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/session", nil)
 
 	h.Session(rec, req)
 
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatal("no cookie should be set without a session store")
+	}
+}
+
+func TestSessionNoop(t *testing.T) {
+	h := testHandler(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/session", nil)
+
+	h.SessionNoop(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatal("noop should not set cookies")
+	}
+}
+
+func TestSession_MiddlewareRejectsMissingBearerToken(t *testing.T) {
+	sessions := auth.NewSessionStore(time.Hour)
+	h := testHandlerWithOptions(t, HandlerOptions{AuthRequired: true, Sessions: sessions})
+	protected := auth.Bearer("secret", sessions)(http.HandlerFunc(h.Session))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/session", nil)
+
+	protected.ServeHTTP(rec, req)
+
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatal("no cookie should be set without authentication")
+	}
+}
+
+func TestSignOut_RevokesSessionAndExpiresCookie(t *testing.T) {
+	sessions := auth.NewSessionStore(time.Hour)
+	id := sessions.Create()
+	h := testHandlerWithOptions(t, HandlerOptions{AuthRequired: true, Sessions: sessions})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/session", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: id})
+
+	h.SignOut(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if sessions.Valid(id) {
+		t.Fatal("session should be revoked after sign-out")
+	}
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("cookies = %d, want 1", len(cookies))
+	}
+	if cookies[0].MaxAge >= 0 {
+		t.Fatalf("cookie MaxAge = %d, want negative (expired)", cookies[0].MaxAge)
+	}
+}
+
+func TestRenderTemplate_UnknownTemplateReturns500(t *testing.T) {
+	h := testHandler(t)
+	rec := httptest.NewRecorder()
+
+	h.renderTemplate(rec, "does-not-exist.html", nil)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
 	}
 }
 
@@ -275,12 +368,14 @@ func TestWorkloadDetail_NotFound(t *testing.T) {
 
 func TestSSE_ConnectsWithSessionCookie(t *testing.T) {
 	h := testHandler(t)
-	protected := auth.Bearer("secret")(http.HandlerFunc(h.SSE))
+	sessions := auth.NewSessionStore(time.Hour)
+	id := sessions.Create()
+	protected := auth.Bearer("secret", sessions)(http.HandlerFunc(h.SSE))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/events", nil)
-	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: "secret"})
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: id})
 	rec := newFlushRecorder()
 
 	done := make(chan struct{})
@@ -314,9 +409,100 @@ func TestSSE_ConnectsWithSessionCookie(t *testing.T) {
 	}
 }
 
+type noFlushWriter struct {
+	header http.Header
+	code   int
+}
+
+func (w *noFlushWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *noFlushWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func (w *noFlushWriter) WriteHeader(code int) { w.code = code }
+
+func TestSSE_RequiresFlusher(t *testing.T) {
+	h := testHandler(t)
+	rec := &noFlushWriter{}
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+
+	h.SSE(rec, req)
+
+	if rec.code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.code, http.StatusInternalServerError)
+	}
+}
+
+func TestSSE_ExitsWhenBrokerShutsDown(t *testing.T) {
+	h := testHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	rec := newFlushRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.SSE(rec, req)
+	}()
+
+	select {
+	case <-rec.wrote:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for SSE greeting")
+	}
+
+	h.broker.Shutdown()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("SSE handler did not exit after broker shutdown")
+	}
+}
+
+func TestSSE_SendsHeartbeat(t *testing.T) {
+	orig := sseHeartbeatInterval
+	sseHeartbeatInterval = 10 * time.Millisecond
+	defer func() { sseHeartbeatInterval = orig }()
+
+	h := testHandler(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/events", nil)
+	rec := newFlushRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.SSE(rec, req)
+	}()
+
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		rec.mu.Lock()
+		got := strings.Contains(rec.body.String(), ": ping\n\n")
+		rec.mu.Unlock()
+		if got {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for heartbeat ping")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	<-done
+}
+
 func TestAuthenticatedSSE_RejectsQueryToken(t *testing.T) {
 	h := testHandler(t)
-	protected := auth.Bearer("secret")(http.HandlerFunc(h.SSE))
+	protected := auth.Bearer("secret", nil)(http.HandlerFunc(h.SSE))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/events?token=secret", nil)
 	rec := httptest.NewRecorder()
@@ -329,6 +515,7 @@ func TestAuthenticatedSSE_RejectsQueryToken(t *testing.T) {
 }
 
 type flushRecorder struct {
+	mu     sync.Mutex
 	header http.Header
 	body   bytes.Buffer
 	code   int
@@ -349,7 +536,9 @@ func (r *flushRecorder) Header() http.Header {
 }
 
 func (r *flushRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
 	n, err := r.body.Write(p)
+	r.mu.Unlock()
 	r.once.Do(func() {
 		close(r.wrote)
 	})

--- a/internal/api/headers.go
+++ b/internal/api/headers.go
@@ -7,7 +7,8 @@ func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
-		w.Header().Set("Content-Security-Policy", "default-src 'self'")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/api/headers_test.go
+++ b/internal/api/headers_test.go
@@ -22,7 +22,8 @@ func TestSecurityHeaders(t *testing.T) {
 	}{
 		{"X-Content-Type-Options", "nosniff"},
 		{"X-Frame-Options", "DENY"},
-		{"Content-Security-Policy", "default-src 'self'"},
+		{"Referrer-Policy", "no-referrer"},
+		{"Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'"},
 	}
 	for _, tt := range tests {
 		got := rec.Header().Get(tt.header)

--- a/internal/api/views.go
+++ b/internal/api/views.go
@@ -27,6 +27,7 @@ type DashboardSummary struct {
 	High     int
 	Medium   int
 	Low      int
+	Unknown  int
 	RAG      RAG
 }
 
@@ -41,6 +42,7 @@ type WorkloadSummary struct {
 	High         int
 	Medium       int
 	Low          int
+	Unknown      int
 	RAG          RAG
 	Vulns        []kube.Vulnerability
 }
@@ -50,32 +52,13 @@ func BuildDashboard(reports []kube.VulnerabilityReport) Dashboard {
 	var dash Dashboard
 
 	for _, r := range reports {
-		workloadName := r.Labels["trivy-operator.resource.name"]
-		workloadKind := r.Labels["trivy-operator.resource.kind"]
-		image := r.Report.Artifact.Repository
-		if r.Report.Artifact.Tag != "" {
-			image += ":" + r.Report.Artifact.Tag
-		}
-
-		ws := WorkloadSummary{
-			Namespace:    r.Namespace,
-			ReportName:   r.Name,
-			WorkloadName: workloadName,
-			WorkloadKind: workloadKind,
-			Image:        image,
-			Critical:     r.Report.Summary.Critical,
-			High:         r.Report.Summary.High,
-			Medium:       r.Report.Summary.Medium,
-			Low:          r.Report.Summary.Low,
-			RAG:          ragFromSummary(r.Report.Summary),
-			Vulns:        r.Report.Vulns,
-		}
-		dash.Workloads = append(dash.Workloads, ws)
+		dash.Workloads = append(dash.Workloads, buildWorkloadSummary(r))
 
 		dash.Summary.Critical += r.Report.Summary.Critical
 		dash.Summary.High += r.Report.Summary.High
 		dash.Summary.Medium += r.Report.Summary.Medium
 		dash.Summary.Low += r.Report.Summary.Low
+		dash.Summary.Unknown += r.Report.Summary.Unknown
 	}
 
 	dash.Summary.RAG = ragFromSummary(kube.Summary{
@@ -83,6 +66,7 @@ func BuildDashboard(reports []kube.VulnerabilityReport) Dashboard {
 		High:     dash.Summary.High,
 		Medium:   dash.Summary.Medium,
 		Low:      dash.Summary.Low,
+		Unknown:  dash.Summary.Unknown,
 	})
 
 	sort.Slice(dash.Workloads, func(i, j int) bool {
@@ -102,11 +86,35 @@ func BuildDashboard(reports []kube.VulnerabilityReport) Dashboard {
 	return dash
 }
 
+func buildWorkloadSummary(r kube.VulnerabilityReport) WorkloadSummary {
+	image := r.Report.Artifact.Repository
+	if r.Report.Artifact.Tag != "" {
+		image += ":" + r.Report.Artifact.Tag
+	}
+
+	return WorkloadSummary{
+		Namespace:    r.Namespace,
+		ReportName:   r.Name,
+		WorkloadName: r.Labels["trivy-operator.resource.name"],
+		WorkloadKind: r.Labels["trivy-operator.resource.kind"],
+		Image:        image,
+		Critical:     r.Report.Summary.Critical,
+		High:         r.Report.Summary.High,
+		Medium:       r.Report.Summary.Medium,
+		Low:          r.Report.Summary.Low,
+		Unknown:      r.Report.Summary.Unknown,
+		RAG:          ragFromSummary(r.Report.Summary),
+		Vulns:        r.Report.Vulns,
+	}
+}
+
+// ragFromSummary buckets a summary: Red for any CRITICAL/HIGH, Amber for
+// MEDIUM or UNKNOWN (unscored vulns must not read as clean), Green otherwise.
 func ragFromSummary(s kube.Summary) RAG {
 	if s.Critical > 0 || s.High > 0 {
 		return RAGRed
 	}
-	if s.Medium > 0 {
+	if s.Medium > 0 || s.Unknown > 0 {
 		return RAGAmber
 	}
 	return RAGGreen

--- a/internal/api/views_test.go
+++ b/internal/api/views_test.go
@@ -35,7 +35,7 @@ func TestBuildDashboard(t *testing.T) {
 			},
 			Report: kube.Report{
 				Artifact: kube.Artifact{Repository: "myorg/api", Tag: "v2"},
-				Summary:  kube.Summary{Critical: 0, High: 0, Medium: 1, Low: 0},
+				Summary:  kube.Summary{Critical: 0, High: 0, Medium: 1, Low: 0, Unknown: 2},
 				Vulns: []kube.Vulnerability{
 					{ID: "CVE-2024-0005", Severity: "MEDIUM", Score: 5.0, Resource: "glibc", InstalledVersion: "2.35", FixedVersion: "2.36", PrimaryLink: "https://avd.aquasec.com/nvd/cve-2024-0005"},
 				},
@@ -53,6 +53,9 @@ func TestBuildDashboard(t *testing.T) {
 	}
 	if dash.Summary.Medium != 1 {
 		t.Errorf("summary medium = %d, want 1", dash.Summary.Medium)
+	}
+	if dash.Summary.Unknown != 2 {
+		t.Errorf("summary unknown = %d, want 2", dash.Summary.Unknown)
 	}
 	if dash.Summary.RAG != RAGRed {
 		t.Errorf("summary RAG = %q, want %q", dash.Summary.RAG, RAGRed)
@@ -143,6 +146,7 @@ func TestRAGStatus(t *testing.T) {
 		{kube.Summary{Critical: 1}, RAGRed},
 		{kube.Summary{High: 1}, RAGRed},
 		{kube.Summary{Medium: 1}, RAGAmber},
+		{kube.Summary{Unknown: 1}, RAGAmber},
 		{kube.Summary{Low: 1}, RAGGreen},
 		{kube.Summary{}, RAGGreen},
 	}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"sync"
+	"time"
+)
+
+// SessionStore mints and validates random browser session IDs so the real
+// bearer token never has to live in a cookie or browser storage.
+type SessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]time.Time
+	ttl      time.Duration
+}
+
+// NewSessionStore creates a SessionStore whose sessions expire after ttl.
+func NewSessionStore(ttl time.Duration) *SessionStore {
+	return &SessionStore{sessions: make(map[string]time.Time), ttl: ttl}
+}
+
+// Create mints a new random session ID and records its expiry. Expired
+// sessions are pruned as a side effect.
+func (s *SessionStore) Create() string {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		panic("auth: crypto/rand failed: " + err.Error())
+	}
+	id := base64.RawURLEncoding.EncodeToString(buf)
+
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k, exp := range s.sessions {
+		if now.After(exp) {
+			delete(s.sessions, k)
+		}
+	}
+	s.sessions[id] = now.Add(s.ttl)
+	return id
+}
+
+// Valid reports whether id is a live session. Expired sessions are removed.
+func (s *SessionStore) Valid(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	exp, ok := s.sessions[id]
+	if !ok {
+		return false
+	}
+	if time.Now().After(exp) {
+		delete(s.sessions, id)
+		return false
+	}
+	return true
+}
+
+// Delete removes a session, if present.
+func (s *SessionStore) Delete(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, id)
+}
+
+// TTL returns the session lifetime.
+func (s *SessionStore) TTL() time.Duration {
+	return s.ttl
+}

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSessionStore_CreateAndValid(t *testing.T) {
+	s := NewSessionStore(time.Hour)
+	id := s.Create()
+	if id == "" {
+		t.Fatal("Create returned empty ID")
+	}
+	if !s.Valid(id) {
+		t.Error("freshly created session should be valid")
+	}
+	if s.Valid("not-a-session") {
+		t.Error("unknown ID should be invalid")
+	}
+}
+
+func TestSessionStore_IDsAreUnique(t *testing.T) {
+	s := NewSessionStore(time.Hour)
+	if s.Create() == s.Create() {
+		t.Error("two sessions got the same ID")
+	}
+}
+
+func TestSessionStore_TTL(t *testing.T) {
+	s := NewSessionStore(time.Hour)
+	if s.TTL() != time.Hour {
+		t.Errorf("TTL = %v, want 1h", s.TTL())
+	}
+}
+
+func TestSessionStore_Expiry(t *testing.T) {
+	s := NewSessionStore(time.Millisecond)
+	id := s.Create()
+	time.Sleep(5 * time.Millisecond)
+	if s.Valid(id) {
+		t.Error("expired session should be invalid")
+	}
+}
+
+func TestSessionStore_Delete(t *testing.T) {
+	s := NewSessionStore(time.Hour)
+	id := s.Create()
+	s.Delete(id)
+	if s.Valid(id) {
+		t.Error("deleted session should be invalid")
+	}
+}
+
+func TestSessionStore_CreatePrunesExpired(t *testing.T) {
+	s := NewSessionStore(time.Millisecond)
+	s.Create()
+	time.Sleep(5 * time.Millisecond)
+	s.Create()
+
+	s.mu.Lock()
+	n := len(s.sessions)
+	s.mu.Unlock()
+	if n != 1 {
+		t.Errorf("sessions = %d, want 1 after pruning", n)
+	}
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -9,12 +9,14 @@ import (
 
 // SessionCookieName is the browser session cookie used by routes that cannot
 // set Authorization headers, such as native EventSource.
-const SessionCookieName = "trivy_dashboard_token"
+const SessionCookieName = "trivy_dashboard_session"
 
-// Bearer returns middleware that requires Authorization: Bearer <expected>.
-// Comparison is constant-time. An empty expected token panics at construction
-// time — a missing token is a startup error, not a runtime 401.
-func Bearer(expected string) func(http.Handler) http.Handler {
+// Bearer returns middleware that requires Authorization: Bearer <expected>,
+// or a valid session cookie minted by sessions (which may be nil to disable
+// cookie auth). Token comparison is constant-time. An empty expected token
+// panics at construction time — a missing token is a startup error, not a
+// runtime 401.
+func Bearer(expected string, sessions *SessionStore) func(http.Handler) http.Handler {
 	if expected == "" {
 		panic("auth.Bearer: empty token")
 	}
@@ -33,8 +35,8 @@ func Bearer(expected string) func(http.Handler) http.Handler {
 				return
 			}
 
-			if cookie, err := r.Cookie(SessionCookieName); err == nil {
-				if subtle.ConstantTimeCompare([]byte(cookie.Value), expectedBytes) == 1 {
+			if sessions != nil {
+				if cookie, err := r.Cookie(SessionCookieName); err == nil && sessions.Valid(cookie.Value) {
 					next.ServeHTTP(w, r)
 					return
 				}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func okHandler() http.Handler {
@@ -13,7 +14,7 @@ func okHandler() http.Handler {
 }
 
 func TestBearer_RejectsMissingHeader(t *testing.T) {
-	h := Bearer("secret")(okHandler())
+	h := Bearer("secret", nil)(okHandler())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/", nil)
 	h.ServeHTTP(rec, req)
@@ -26,7 +27,7 @@ func TestBearer_RejectsMissingHeader(t *testing.T) {
 }
 
 func TestBearer_RejectsWrongToken(t *testing.T) {
-	h := Bearer("secret")(okHandler())
+	h := Bearer("secret", nil)(okHandler())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer nope")
@@ -37,7 +38,7 @@ func TestBearer_RejectsWrongToken(t *testing.T) {
 }
 
 func TestBearer_AcceptsCorrectToken(t *testing.T) {
-	h := Bearer("secret")(okHandler())
+	h := Bearer("secret", nil)(okHandler())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer secret")
@@ -48,7 +49,7 @@ func TestBearer_AcceptsCorrectToken(t *testing.T) {
 }
 
 func TestBearer_RejectsBasicScheme(t *testing.T) {
-	h := Bearer("secret")(okHandler())
+	h := Bearer("secret", nil)(okHandler())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Basic secret")
@@ -59,18 +60,21 @@ func TestBearer_RejectsBasicScheme(t *testing.T) {
 }
 
 func TestBearer_AllowsSessionCookie(t *testing.T) {
-	h := Bearer("secret")(okHandler())
+	sessions := NewSessionStore(time.Hour)
+	id := sessions.Create()
+	h := Bearer("secret", sessions)(okHandler())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/", nil)
-	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: "secret"})
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: id})
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
 }
 
-func TestBearer_RejectsWrongSessionCookie(t *testing.T) {
-	h := Bearer("secret")(okHandler())
+func TestBearer_RejectsUnknownSessionCookie(t *testing.T) {
+	sessions := NewSessionStore(time.Hour)
+	h := Bearer("secret", sessions)(okHandler())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: "wrong"})
@@ -80,8 +84,31 @@ func TestBearer_RejectsWrongSessionCookie(t *testing.T) {
 	}
 }
 
+func TestBearer_RejectsTokenValueAsSessionCookie(t *testing.T) {
+	sessions := NewSessionStore(time.Hour)
+	h := Bearer("secret", sessions)(okHandler())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: "secret"})
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 — raw token must not work as a session ID", rec.Code)
+	}
+}
+
+func TestBearer_NilSessionStoreIgnoresCookies(t *testing.T) {
+	h := Bearer("secret", nil)(okHandler())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: "secret"})
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
 func TestBearer_RejectsQueryToken(t *testing.T) {
-	h := Bearer("secret")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := Bearer("secret", nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
 	rec := httptest.NewRecorder()
@@ -98,5 +125,5 @@ func TestBearer_EmptyTokenPanics(t *testing.T) {
 			t.Errorf("expected panic on empty token")
 		}
 	}()
-	Bearer("")
+	Bearer("", nil)
 }

--- a/internal/kube/client_test.go
+++ b/internal/kube/client_test.go
@@ -78,6 +78,77 @@ func TestParseVulnerabilityReport(t *testing.T) {
 	}
 }
 
+func TestParseVulnerabilityReport_Float64Counts(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "r",
+				"namespace": "default",
+			},
+			"report": map[string]interface{}{
+				"summary": map[string]interface{}{
+					"criticalCount": float64(3),
+					"unknownCount":  float64(1),
+				},
+			},
+		},
+	}
+
+	report, err := ParseVulnerabilityReport(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Report.Summary.Critical != 3 {
+		t.Errorf("critical = %d, want 3", report.Report.Summary.Critical)
+	}
+	if report.Report.Summary.Unknown != 1 {
+		t.Errorf("unknown = %d, want 1", report.Report.Summary.Unknown)
+	}
+}
+
+func TestParseVulnerabilityReport_SkipsMalformedVulnEntry(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "r",
+				"namespace": "default",
+			},
+			"report": map[string]interface{}{
+				"vulnerabilities": []interface{}{
+					"not-a-map",
+					map[string]interface{}{"vulnerabilityID": "CVE-1", "severity": "LOW"},
+				},
+			},
+		},
+	}
+
+	report, err := ParseVulnerabilityReport(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(report.Report.Vulns) != 1 {
+		t.Fatalf("vulns = %d, want 1 (malformed entry skipped)", len(report.Report.Vulns))
+	}
+	if report.Report.Vulns[0].ID != "CVE-1" {
+		t.Errorf("vuln ID = %q, want CVE-1", report.Report.Vulns[0].ID)
+	}
+}
+
+func TestParseVulnerabilityReport_MissingReportField(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "r",
+				"namespace": "default",
+			},
+		},
+	}
+
+	if _, err := ParseVulnerabilityReport(obj); err == nil {
+		t.Fatal("expected error for missing report field")
+	}
+}
+
 func TestStore(t *testing.T) {
 	s := NewStore()
 	if s.IsSynced() {
@@ -87,6 +158,16 @@ func TestStore(t *testing.T) {
 	s.Set(r)
 	if got := s.Len(); got != 1 {
 		t.Fatalf("Len() = %d, want 1", got)
+	}
+	got, ok := s.Get("default", "test-report")
+	if !ok {
+		t.Fatal("Get should find the stored report")
+	}
+	if got.Name != "test-report" {
+		t.Errorf("Get name = %q, want test-report", got.Name)
+	}
+	if _, ok := s.Get("default", "missing"); ok {
+		t.Error("Get should miss for unknown name")
 	}
 	all := s.All() // all is now []VulnerabilityReport, not []*VulnerabilityReport
 	if len(all) != 1 {
@@ -131,5 +212,27 @@ func TestStoreAllReturnsDeepCopies(t *testing.T) {
 	}
 	if second[0].Report.Vulns[0].ID != "CVE-1" {
 		t.Fatalf("vulnerability was mutated through snapshot")
+	}
+}
+
+func TestStoreGetReturnsDeepCopy(t *testing.T) {
+	s := NewStore()
+	s.Set(&VulnerabilityReport{
+		Name:      "report",
+		Namespace: "default",
+		Report: Report{
+			Vulns: []Vulnerability{{ID: "CVE-1", Severity: "HIGH"}},
+		},
+	})
+
+	first, ok := s.Get("default", "report")
+	if !ok {
+		t.Fatal("Get should find the stored report")
+	}
+	first.Report.Vulns[0].ID = "mutated"
+
+	second, _ := s.Get("default", "report")
+	if second.Report.Vulns[0].ID != "CVE-1" {
+		t.Fatal("vulnerability was mutated through Get copy")
 	}
 }

--- a/internal/kube/store.go
+++ b/internal/kube/store.go
@@ -28,6 +28,17 @@ func (s *Store) Delete(namespace, name string) {
 	delete(s.reports, namespace+"/"+name)
 }
 
+// Get returns a copy of the report for namespace/name, if present.
+func (s *Store) Get(namespace, name string) (VulnerabilityReport, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.reports[namespace+"/"+name]
+	if !ok {
+		return VulnerabilityReport{}, false
+	}
+	return cloneReport(r), true
+}
+
 // All returns a snapshot of all reports in the store as value copies.
 func (s *Store) All() []VulnerabilityReport {
 	s.mu.RLock()

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -12,6 +12,8 @@ type Metrics struct {
 	requestDuration *prometheus.HistogramVec
 	storeReports    prometheus.Gauge
 	storeSynced     prometheus.Gauge
+	watchHealthy    prometheus.Gauge
+	watchErrors     prometheus.Counter
 }
 
 // New creates and registers all metrics with the given registry.
@@ -30,8 +32,16 @@ func New(reg prometheus.Registerer) *Metrics {
 			Name: "trivy_dashboard_store_synced",
 			Help: "Whether the informer cache is synced (1=yes, 0=no).",
 		}),
+		watchHealthy: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "trivy_dashboard_watch_healthy",
+			Help: "Whether the report watch is healthy (1=yes, 0=last attempt errored).",
+		}),
+		watchErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "trivy_dashboard_watch_errors_total",
+			Help: "Total watch/list errors from the informer.",
+		}),
 	}
-	reg.MustRegister(m.requestDuration, m.storeReports, m.storeSynced)
+	reg.MustRegister(m.requestDuration, m.storeReports, m.storeSynced, m.watchHealthy, m.watchErrors)
 	return m
 }
 
@@ -52,4 +62,18 @@ func (m *Metrics) SetSynced(synced bool) {
 	} else {
 		m.storeSynced.Set(0)
 	}
+}
+
+// SetWatchHealthy sets the watch health gauge (1 or 0).
+func (m *Metrics) SetWatchHealthy(healthy bool) {
+	if healthy {
+		m.watchHealthy.Set(1)
+	} else {
+		m.watchHealthy.Set(0)
+	}
+}
+
+// IncWatchErrors increments the watch error counter.
+func (m *Metrics) IncWatchErrors() {
+	m.watchErrors.Inc()
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -56,3 +56,41 @@ func TestStoreMetrics(t *testing.T) {
 		t.Errorf("expected store_synced 1, got:\n%s", body)
 	}
 }
+
+func TestSetSyncedFalse(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg)
+
+	m.SetSynced(true)
+	m.SetSynced(false)
+
+	metricsRec := httptest.NewRecorder()
+	metricsReq := httptest.NewRequest("GET", "/metrics", nil)
+	promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).ServeHTTP(metricsRec, metricsReq)
+
+	if !strings.Contains(metricsRec.Body.String(), "trivy_dashboard_store_synced 0") {
+		t.Errorf("expected store_synced 0, got:\n%s", metricsRec.Body.String())
+	}
+}
+
+func TestWatchMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := New(reg)
+
+	m.SetWatchHealthy(true)
+	m.IncWatchErrors()
+	m.IncWatchErrors()
+	m.SetWatchHealthy(false)
+
+	metricsRec := httptest.NewRecorder()
+	metricsReq := httptest.NewRequest("GET", "/metrics", nil)
+	promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).ServeHTTP(metricsRec, metricsReq)
+
+	body := metricsRec.Body.String()
+	if !strings.Contains(body, "trivy_dashboard_watch_healthy 0") {
+		t.Errorf("expected watch_healthy 0, got:\n%s", body)
+	}
+	if !strings.Contains(body, "trivy_dashboard_watch_errors_total 2") {
+		t.Errorf("expected watch_errors_total 2, got:\n%s", body)
+	}
+}

--- a/internal/views/static/app.js
+++ b/internal/views/static/app.js
@@ -1,56 +1,61 @@
 (() => {
-  const TOKEN_KEY = "trivy-dashboard.token";
   const content = document.getElementById("content");
   const refreshTime = document.getElementById("refresh-time");
   const refreshBtn = document.getElementById("refresh");
   const signoutBtn = document.getElementById("signout");
+  const filterInput = document.getElementById("filter");
+  const login = document.getElementById("login");
+  const loginForm = document.getElementById("login-form");
+  const tokenInput = document.getElementById("token-input");
+  const loginError = document.getElementById("login-error");
   const authRequired = document.getElementById("auth-required")?.dataset.required !== "false";
 
   let eventSource = null;
 
-  function getToken() {
-    if (!authRequired) return "";
-    let t = sessionStorage.getItem(TOKEN_KEY);
-    if (!t) {
-      t = window.prompt("Enter trivy-dashboard bearer token:");
-      if (t) sessionStorage.setItem(TOKEN_KEY, t);
+  function closeSSE() {
+    if (eventSource) {
+      eventSource.close();
+      eventSource = null;
     }
-    return t;
   }
 
-  function clearToken() {
-    sessionStorage.removeItem(TOKEN_KEY);
+  function showLogin(message) {
+    closeSSE();
+    content.innerHTML = "";
+    login.hidden = false;
+    loginError.textContent = message || "";
+    loginError.hidden = !message;
   }
 
-  async function establishSession() {
-    if (!authRequired) return true;
-    const token = getToken();
-    if (!token) return false;
+  function hideLogin() {
+    login.hidden = true;
+    loginError.hidden = true;
+  }
+
+  // Exchanges the token for an HTTP-only session cookie. The token is used
+  // for this one request and never stored client-side.
+  async function submitToken(token) {
     const res = await fetch("/api/session", {
       method: "POST",
       headers: { "Authorization": "Bearer " + token }
     });
     if (res.status === 401) {
-      clearToken();
-      content.innerHTML = '<p class="error">Unauthorized - token cleared. Refresh to re-enter.</p>';
+      showLogin("Invalid token.");
       return false;
     }
     if (!res.ok) {
-      content.innerHTML = '<p class="error">Error: ' + res.status + '</p>';
+      showLogin("Error: " + res.status);
       return false;
     }
+    hideLogin();
+    await start();
     return true;
   }
 
   async function authedFetch(path) {
-    const token = getToken();
-    if (authRequired && !token) return null;
-    const headers = {};
-    if (authRequired) headers.Authorization = "Bearer " + token;
-    const res = await fetch(path, { headers });
+    const res = await fetch(path);
     if (res.status === 401) {
-      clearToken();
-      content.innerHTML = '<p class="error">Unauthorized - token cleared. Refresh to re-enter.</p>';
+      showLogin();
       return null;
     }
     if (!res.ok) {
@@ -60,68 +65,108 @@
     return res.text();
   }
 
-  async function loadDashboard() {
-    const html = await authedFetch("/api/dashboard");
-    if (html === null) return;
-    content.innerHTML = html;
-    refreshTime.textContent = new Date().toLocaleTimeString();
-    attachRowHandlers();
-  }
-
   function buildWorkloadPath(ns, name) {
     return "/workload/" + encodeURIComponent(ns) + "/" + encodeURIComponent(name);
   }
 
+  function rowKey(row) {
+    return row.dataset.ns + "/" + row.dataset.name;
+  }
+
+  async function expandRow(row) {
+    row.classList.add("expanded");
+    const detail = row.nextElementSibling.querySelector("td");
+    const html = await authedFetch(buildWorkloadPath(row.dataset.ns, row.dataset.name));
+    if (html !== null) detail.innerHTML = html;
+  }
+
+  function collapseRow(row) {
+    row.classList.remove("expanded");
+    row.nextElementSibling.querySelector("td").innerHTML = "";
+  }
+
   function attachRowHandlers() {
-    document.querySelectorAll(".workload-row").forEach(function(row) {
-      row.addEventListener("click", async function() {
-        var detail = this.nextElementSibling.querySelector("td");
-        if (this.classList.toggle("expanded")) {
-          var ns = this.dataset.ns;
-          var name = this.dataset.name;
-          var html = await authedFetch(buildWorkloadPath(ns, name));
-          if (html !== null) detail.innerHTML = html;
+    content.querySelectorAll(".workload-row").forEach(function(row) {
+      row.addEventListener("click", function() {
+        if (row.classList.contains("expanded")) {
+          collapseRow(row);
         } else {
-          detail.innerHTML = "";
+          expandRow(row);
         }
       });
     });
   }
 
-  async function connectSSE() {
-    if (eventSource) eventSource.close();
+  function applyFilter() {
+    const query = filterInput.value.trim().toLowerCase();
+    content.querySelectorAll(".workload-row").forEach(function(row) {
+      const match = !query || row.textContent.toLowerCase().includes(query);
+      row.hidden = !match;
+      row.nextElementSibling.hidden = !match;
+    });
+  }
 
-    const ok = await establishSession();
-    if (!ok) return;
+  async function loadDashboard() {
+    const html = await authedFetch("/api/dashboard");
+    if (html === null) return false;
 
+    const expanded = new Set();
+    content.querySelectorAll(".workload-row.expanded").forEach(function(row) {
+      expanded.add(rowKey(row));
+    });
+
+    content.innerHTML = html;
+    refreshTime.textContent = new Date().toLocaleTimeString();
+    attachRowHandlers();
+    content.querySelectorAll(".workload-row").forEach(function(row) {
+      if (expanded.has(rowKey(row))) expandRow(row);
+    });
+    applyFilter();
+    return true;
+  }
+
+  function connectSSE() {
+    closeSSE();
     eventSource = new EventSource("/api/events");
-
     eventSource.addEventListener("refresh", function() {
       loadDashboard();
     });
-
     eventSource.onerror = function() {
       // EventSource auto-reconnects
     };
   }
 
+  async function start() {
+    const ok = await loadDashboard();
+    if (ok) connectSSE();
+  }
+
   if (window.__TRIVY_DASHBOARD_TEST__) {
     window.TrivyDashboardTest = {
+      applyFilter,
       authedFetch,
       buildWorkloadPath,
-      connectSSE,
-      establishSession
+      start,
+      submitToken
     };
   }
 
-  refreshBtn.addEventListener("click", loadDashboard);
-  signoutBtn.addEventListener("click", function() {
-    clearToken();
-    if (eventSource) eventSource.close();
-    content.innerHTML = "";
-    refreshTime.textContent = "—";
+  loginForm.addEventListener("submit", function(e) {
+    e.preventDefault();
+    const token = tokenInput.value.trim();
+    tokenInput.value = "";
+    if (token) submitToken(token);
   });
 
-  loadDashboard();
-  connectSSE();
+  filterInput.addEventListener("input", applyFilter);
+  refreshBtn.addEventListener("click", loadDashboard);
+  signoutBtn.addEventListener("click", async function() {
+    if (authRequired) await fetch("/api/session", { method: "DELETE" });
+    closeSSE();
+    content.innerHTML = "";
+    refreshTime.textContent = "—";
+    if (authRequired) showLogin();
+  });
+
+  start();
 })();

--- a/internal/views/static/style.css
+++ b/internal/views/static/style.css
@@ -52,6 +52,7 @@ header h1 {
 .count.high     { color: #ff7043; }
 .count.medium   { color: #ffa726; }
 .count.low      { color: #66bb6a; }
+.count.unknown  { color: #9ea7b3; }
 
 .workloads {
     width: 100%;
@@ -108,5 +109,33 @@ header h1 {
 .severity-HIGH td:first-child     { border-left: 3px solid #ff7043; }
 .severity-MEDIUM td:first-child   { border-left: 3px solid #ffa726; }
 .severity-LOW td:first-child      { border-left: 3px solid #66bb6a; }
+.severity-UNKNOWN td:first-child  { border-left: 3px solid #6e7681; }
 
 .no-fix { color: #6e7681; font-style: italic; }
+
+#filter {
+    padding: 0.3rem 0.8rem;
+    background: #0f1117;
+    color: #e1e4e8;
+    border: 1px solid #363b42;
+    border-radius: 4px;
+    font-size: 0.85rem;
+}
+
+#login form {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+#token-input {
+    padding: 0.3rem 0.8rem;
+    background: #0f1117;
+    color: #e1e4e8;
+    border: 1px solid #363b42;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    width: 20rem;
+}
+
+.error { color: #ef5350; }

--- a/internal/views/static_test/app.test.mjs
+++ b/internal/views/static_test/app.test.mjs
@@ -5,7 +5,6 @@ import vm from "node:vm";
 
 async function loadApp(options = {}) {
   const script = await readFile(new URL("../static/app.js", import.meta.url), "utf8");
-  const store = new Map();
   const elements = new Map();
   const eventSourceURLs = [];
   const fetchCalls = [];
@@ -17,18 +16,22 @@ async function loadApp(options = {}) {
         dataset: {},
         innerHTML: "",
         textContent: "",
-        addEventListener() {}
+        value: "",
+        hidden: false,
+        addEventListener() {},
+        querySelectorAll() {
+          return [];
+        }
       });
     }
     return elements.get(id);
   }
 
+  let authorized = !options.unauthorized;
+
   const context = {
     document: {
-      getElementById: element,
-      querySelectorAll() {
-        return [];
-      }
+      getElementById: element
     },
     EventSource: class {
       constructor(url) {
@@ -40,43 +43,42 @@ async function loadApp(options = {}) {
     },
     fetch: async (path, init = {}) => {
       fetchCalls.push({ path, init });
-      if (options.unauthorized) {
-        return { status: 401, ok: false, text: async () => "" };
-      }
-      if (path === "/api/session") {
+      if (path === "/api/session" && init.method === "POST") {
+        if (options.sessionUnauthorized) {
+          return { status: 401, ok: false, text: async () => "" };
+        }
+        authorized = true;
         return { status: 204, ok: true, text: async () => "" };
+      }
+      if (path === "/api/session" && init.method === "DELETE") {
+        authorized = false;
+        return { status: 204, ok: true, text: async () => "" };
+      }
+      if (!authorized) {
+        return { status: 401, ok: false, text: async () => "" };
       }
       return { status: 200, ok: true, text: async () => "<div></div>" };
     },
-    sessionStorage: {
-      getItem(key) {
-        return store.get(key) || null;
-      },
-      setItem(key, value) {
-        store.set(key, value);
-      },
-      removeItem(key) {
-        store.delete(key);
-      }
-    },
     window: {
-      __TRIVY_DASHBOARD_TEST__: true,
-      prompt() {
-        return options.promptToken || "secret";
-      }
+      __TRIVY_DASHBOARD_TEST__: true
     }
   };
   element("auth-required").dataset.required = options.authRequired === false ? "false" : "true";
   context.window.document = context.document;
   context.window.EventSource = context.EventSource;
   context.window.fetch = context.fetch;
-  context.window.sessionStorage = context.sessionStorage;
 
   vm.runInNewContext(script, context);
   await new Promise((resolve) => setImmediate(resolve));
 
-  return { context, elements, eventSourceURLs, fetchCalls, store };
+  return { context, elements, eventSourceURLs, fetchCalls, script };
 }
+
+test("token is never persisted to browser storage", async () => {
+  const { script } = await loadApp();
+
+  assert.doesNotMatch(script, /sessionStorage|localStorage/);
+});
 
 test("buildWorkloadPath encodes namespace and name", async () => {
   const { context } = await loadApp();
@@ -87,36 +89,60 @@ test("buildWorkloadPath encodes namespace and name", async () => {
   );
 });
 
-test("EventSource URL does not contain token", async () => {
-  const { eventSourceURLs } = await loadApp();
-
-  assert.deepEqual(eventSourceURLs, ["/api/events"]);
-});
-
-test("session setup sends bearer header without query credentials", async () => {
-  const { fetchCalls } = await loadApp();
-  const sessionCall = fetchCalls.find((call) => call.path === "/api/session");
-
-  assert.equal(sessionCall.init.method, "POST");
-  assert.equal(sessionCall.init.headers.Authorization, "Bearer secret");
-});
-
-test("401 clears stored token and shows unauthorized message", async () => {
-  const { context, elements, store } = await loadApp({ unauthorized: true });
-
-  context.sessionStorage.setItem("trivy-dashboard.token", "secret");
-  await context.window.TrivyDashboardTest.authedFetch("/api/dashboard");
-
-  assert.equal(store.has("trivy-dashboard.token"), false);
-  assert.match(elements.get("content").innerHTML, /Unauthorized/);
-});
-
-test("tokenless mode fetches without prompt or bearer header", async () => {
-  const { context, fetchCalls } = await loadApp({ authRequired: false });
-
-  await context.window.TrivyDashboardTest.authedFetch("/api/dashboard");
+test("valid session cookie loads dashboard and connects SSE without credentials", async () => {
+  const { eventSourceURLs, fetchCalls } = await loadApp();
 
   const dashboardCall = fetchCalls.find((call) => call.path === "/api/dashboard");
-  assert.equal(dashboardCall.init.headers.Authorization, undefined);
+  assert.ok(dashboardCall, "dashboard should be fetched on start");
+  assert.equal(dashboardCall.init.headers, undefined);
+  assert.deepEqual(eventSourceURLs, ["/api/events"]);
   assert.equal(fetchCalls.some((call) => call.path === "/api/session"), false);
+});
+
+test("401 on dashboard shows login form and skips SSE", async () => {
+  const { elements, eventSourceURLs } = await loadApp({ unauthorized: true });
+
+  assert.equal(elements.get("login").hidden, false);
+  assert.equal(elements.get("content").innerHTML, "");
+  assert.deepEqual(eventSourceURLs, []);
+});
+
+test("submitToken exchanges bearer token once then uses cookie", async () => {
+  const { context, elements, eventSourceURLs, fetchCalls } = await loadApp({ unauthorized: true });
+
+  const ok = await context.window.TrivyDashboardTest.submitToken("secret");
+
+  assert.equal(ok, true);
+  const sessionCall = fetchCalls.find((call) => call.path === "/api/session");
+  assert.equal(sessionCall.init.method, "POST");
+  assert.equal(sessionCall.init.headers.Authorization, "Bearer secret");
+
+  const dashboardCall = fetchCalls.findLast((call) => call.path === "/api/dashboard");
+  assert.equal(dashboardCall.init.headers, undefined);
+  assert.deepEqual(eventSourceURLs, ["/api/events"]);
+  assert.equal(elements.get("login").hidden, true);
+});
+
+test("submitToken with bad token shows error and no SSE", async () => {
+  const { context, elements, eventSourceURLs } = await loadApp({
+    unauthorized: true,
+    sessionUnauthorized: true
+  });
+
+  const ok = await context.window.TrivyDashboardTest.submitToken("wrong");
+
+  assert.equal(ok, false);
+  assert.equal(elements.get("login").hidden, false);
+  assert.equal(elements.get("login-error").hidden, false);
+  assert.match(elements.get("login-error").textContent, /Invalid token/);
+  assert.deepEqual(eventSourceURLs, []);
+});
+
+test("tokenless mode never calls the session endpoint", async () => {
+  const { eventSourceURLs, fetchCalls } = await loadApp({ authRequired: false });
+
+  assert.equal(fetchCalls.some((call) => call.path === "/api/session"), false);
+  const dashboardCall = fetchCalls.find((call) => call.path === "/api/dashboard");
+  assert.equal(dashboardCall.init.headers, undefined);
+  assert.deepEqual(eventSourceURLs, ["/api/events"]);
 });

--- a/internal/views/templates/dashboard.html
+++ b/internal/views/templates/dashboard.html
@@ -3,6 +3,7 @@
     <span class="count high">{{.Summary.High}} High</span>
     <span class="count medium">{{.Summary.Medium}} Medium</span>
     <span class="count low">{{.Summary.Low}} Low</span>
+    <span class="count unknown">{{.Summary.Unknown}} Unknown</span>
 </div>
 
 <table class="workloads">
@@ -14,6 +15,7 @@
             <th>High</th>
             <th>Medium</th>
             <th>Low</th>
+            <th>Unknown</th>
             <th>Status</th>
         </tr>
     </thead>
@@ -26,9 +28,10 @@
             <td class="count">{{.High}}</td>
             <td class="count">{{.Medium}}</td>
             <td class="count">{{.Low}}</td>
+            <td class="count">{{.Unknown}}</td>
             <td><span class="rag-badge rag-{{.RAG}}">{{.RAG}}</span></td>
         </tr>
-        <tr class="workload-detail"><td colspan="7"></td></tr>
+        <tr class="workload-detail"><td colspan="8"></td></tr>
         {{end}}
     </tbody>
 </table>

--- a/internal/views/templates/index.html
+++ b/internal/views/templates/index.html
@@ -12,10 +12,19 @@
         <h1>Vulnerability Dashboard</h1>
         <div class="toolbar">
             <span class="last-refresh">Last refresh: <time id="refresh-time">—</time></span>
+            <input type="search" id="filter" placeholder="Filter workloads…">
             <button class="refresh-btn" id="refresh">Refresh</button>
             <button class="refresh-btn" id="signout">Sign out</button>
         </div>
     </header>
+
+    <div id="login" hidden>
+        <form id="login-form">
+            <input type="password" id="token-input" placeholder="Bearer token" autocomplete="current-password">
+            <button type="submit" class="refresh-btn">Sign in</button>
+        </form>
+        <p id="login-error" class="error" hidden></p>
+    </div>
 
     <div id="content"></div>
 

--- a/internal/views/templates/workload-detail.html
+++ b/internal/views/templates/workload-detail.html
@@ -15,7 +15,7 @@
         <tr class="severity-{{.Severity}}">
             <td><a href="{{safeURL .PrimaryLink}}" target="_blank" rel="noopener">{{.ID}}</a></td>
             <td>{{.Severity}}</td>
-            <td>{{printf "%.1f" .Score}}</td>
+            <td>{{if .Score}}{{printf "%.1f" .Score}}{{else}}<span class="no-fix">—</span>{{end}}</td>
             <td>{{.Resource}}</td>
             <td>{{.InstalledVersion}}</td>
             <td>{{if .FixedVersion}}{{.FixedVersion}}{{else}}<span class="no-fix">no fix</span>{{end}}</td>

--- a/main.go
+++ b/main.go
@@ -85,18 +85,37 @@ func main() {
 
 	store := kube.NewStore()
 	broker := api.NewBroker(500 * time.Millisecond)
-	defer broker.Shutdown()
+	reg.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "trivy_dashboard_sse_clients",
+		Help: "Number of connected SSE clients.",
+	}, func() float64 { return float64(broker.SubscriberCount()) }))
 
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 30*time.Minute, "", nil)
 	informer := factory.ForResource(vulnReportGVR).Informer()
+
+	if err := informer.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		logger.Warn("informer watch error", "err", err)
+		m.SetWatchHealthy(false)
+		m.IncWatchErrors()
+	}); err != nil {
+		logger.Error("failed to set watch error handler", "err", err)
+		os.Exit(1)
+	}
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{ //nolint:errcheck // registration never fails for shared informers
 		AddFunc: func(obj interface{}) {
 			handleEvent(store, obj)
 			m.SetStoreSize(store.Len())
+			m.SetWatchHealthy(true)
 			broker.Notify()
 		},
-		UpdateFunc: func(_, obj interface{}) {
+		UpdateFunc: func(oldObj, obj interface{}) {
+			m.SetWatchHealthy(true)
+			if oldU, ok := oldObj.(*unstructured.Unstructured); ok {
+				if newU, ok := obj.(*unstructured.Unstructured); ok && oldU.GetResourceVersion() == newU.GetResourceVersion() {
+					return // periodic resync, nothing changed
+				}
+			}
 			handleEvent(store, obj)
 			m.SetStoreSize(store.Len())
 			broker.Notify()
@@ -130,6 +149,7 @@ func main() {
 	}
 	store.MarkSynced()
 	m.SetSynced(true)
+	m.SetWatchHealthy(true)
 	logger.Info("informer cache synced")
 
 	mux := http.NewServeMux()
@@ -151,14 +171,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	var sessions *auth.SessionStore
+	if token != "" {
+		sessions = auth.NewSessionStore(24 * time.Hour)
+	}
+
 	handler := api.NewHandler(store, tmpl, broker, api.HandlerOptions{
 		AuthRequired:  token != "",
 		SecureCookies: secureCookies,
+		Sessions:      sessions,
 	})
 	mux.HandleFunc("GET /", handler.Index)
 	if token != "" {
-		authed := auth.Bearer(token)
+		authed := auth.Bearer(token, sessions)
 		mux.Handle("POST /api/session", authed(http.HandlerFunc(handler.Session)))
+		mux.HandleFunc("DELETE /api/session", handler.SignOut)
 		mux.Handle("GET /api/dashboard", authed(http.HandlerFunc(handler.DashboardContent)))
 		mux.Handle("GET /workload/{namespace}/{report}", authed(http.HandlerFunc(handler.WorkloadDetail)))
 		mux.Handle("GET /api/events", authed(http.HandlerFunc(handler.SSE)))
@@ -201,6 +228,10 @@ func main() {
 		logger.Info("shutting down")
 	}
 
+	// Close SSE subscriber channels first so streaming handlers unwind;
+	// otherwise srv.Shutdown blocks on them until its deadline.
+	broker.Shutdown()
+
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
@@ -221,5 +252,5 @@ func handleEvent(store *kube.Store, obj interface{}) {
 		return
 	}
 	store.Set(report)
-	slog.Info("synced vulnerability report", "namespace", report.Namespace, "name", report.Name)
+	slog.Debug("synced vulnerability report", "namespace", report.Namespace, "name", report.Name)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/tobydoescode/trivy-dashboard/internal/kube"
+)
+
+func vulnReportObj(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"report": map[string]interface{}{
+				"summary": map[string]interface{}{
+					"criticalCount": int64(1),
+				},
+			},
+		},
+	}
+}
+
+func TestHandleEvent_StoresParsedReport(t *testing.T) {
+	store := kube.NewStore()
+
+	handleEvent(store, vulnReportObj("report-a", "web"))
+
+	got, ok := store.Get("web", "report-a")
+	if !ok {
+		t.Fatal("report should be stored")
+	}
+	if got.Report.Summary.Critical != 1 {
+		t.Errorf("critical = %d, want 1", got.Report.Summary.Critical)
+	}
+}
+
+func TestHandleEvent_IgnoresNonUnstructured(t *testing.T) {
+	store := kube.NewStore()
+
+	handleEvent(store, "not-an-object")
+
+	if store.Len() != 0 {
+		t.Errorf("store len = %d, want 0", store.Len())
+	}
+}
+
+func TestHandleEvent_IgnoresUnparseableReport(t *testing.T) {
+	store := kube.NewStore()
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "broken",
+				"namespace": "web",
+			},
+			// no report field
+		},
+	}
+
+	handleEvent(store, obj)
+
+	if store.Len() != 0 {
+		t.Errorf("store len = %d, want 0", store.Len())
+	}
+}


### PR DESCRIPTION
Applies the fixes from a full code review of the app.

## High — runtime bugs
- **Shutdown hang**: `Broker.Shutdown` now closes all subscriber channels (idempotent) and runs before `srv.Shutdown`, so SSE handlers unwind and rollouts exit 0 instead of burning the 10s deadline and exiting 1.
- **SSE 60s cutoff**: the SSE handler clears its write deadline via `http.NewResponseController` and sends `: ping` every 30s, so streams survive the server `WriteTimeout` and proxy idle timeouts.

## Medium
- **Sessions**: new `auth.SessionStore` mints random 256-bit session IDs (24h TTL, in-memory). Cookie carries the ID, never the bearer token; token used for exactly one `POST /api/session` request and never stored client-side (`sessionStorage` gone, inline login form replaces `window.prompt`). `DELETE /api/session` revokes.
- **Resync churn**: `UpdateFunc` skips resourceVersion no-ops; per-report sync log demoted to Debug.
- **Watch health**: `SetWatchErrorHandler` + `trivy_dashboard_watch_healthy`, `trivy_dashboard_watch_errors_total`, `trivy_dashboard_sse_clients` metrics.
- **UNKNOWN severity**: own summary tile + table column, folds into Amber so unknown-only reports can't render Green.
- **`Store.Get`**: workload detail fetches one report instead of building the whole dashboard.
- **UX**: expanded rows survive live refreshes; workload filter box added.

## Low
- Debounce max-wait cap (4×) prevents notify-storm starvation; `NewHandler` takes plain `HandlerOptions`; unscored CVEs render `—` not `0.0`; `Referrer-Policy` + `frame-ancestors 'none'` headers.

## Behavior notes
- Sessions are in-memory: pod restart signs all browsers out (login form shown).
- Cookie renamed `trivy_dashboard_session` (value is no longer the token).

## Testing
- 30+ new/updated tests; `go test -race ./...` clean; JS suite 7/7.
- Coverage 59.8% → 66.6% (remaining gap is `main()` wiring, covered by build-tagged smoke tests).
- Smoke test assertions verified compatible with the new templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)