### PR TITLE
test: silence SA4000 in session uniqueness test

### DIFF
--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -21,7 +21,9 @@ func TestSessionStore_CreateAndValid(t *testing.T) {
 
 func TestSessionStore_IDsAreUnique(t *testing.T) {
 	s := NewSessionStore(time.Hour)
-	if s.Create() == s.Create() {
+	first := s.Create()
+	second := s.Create()
+	if first == second {
 		t.Error("two sessions got the same ID")
 	}
 }


### PR DESCRIPTION
Fixes the main CI failure from #17: staticcheck SA4000 flags
`s.Create() == s.Create()` as identical expressions. Assign to
locals before comparing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)