### PR TITLE
fix(ci): correct postUpdateOptions typo so Renovate tidies go.sum

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "postUpdateOptions": ["goModTidy"],
+  "postUpdateOptions": ["gomodTidy"],
   "assignees": ["tobydoescode"],
   "packageRules": [
     {


### PR DESCRIPTION
## Root cause

`renovate.json` spelled the option `goModTidy`. Renovate's value is **`gomodTidy`** — lowercase `m`. The [documented values](https://docs.renovatebot.com/configuration-options/#postupdateoptions) are `goGenerate`, `gomodMassage`, `gomodSkipVendor`, `gomodTidy`, `gomodTidy1.17`, `gomodTidyE`, `gomodUpdateImportPaths`, `gomodVendor`.

Renovate ignores unrecognised `postUpdateOptions` values silently, so it has never run `go mod tidy` on this repo.

## Evidence

From the Renovate job logs (`2026-07-28 16:12 UTC`, the run that rebased the open dependency branches), the complete list of commands executed per branch:

```
install-tool golang 1.26.5
go get -t ./...
```

No tidy step. No WARN or ERROR at any level in the logs, and nothing on the Dependency Dashboard — the invalid value is dropped without complaint.

This matches the observed symptom exactly: the committed `go.sum` reproduces from `go get` alone (verified by diffing Renovate's `go.sum` against a local `go get` with no tidy — a one-line difference), leaving stale entries that fail the `Check go mod tidy` step in `.github/actions/test/action.yaml`.

Note this rules out the Go toolchain as a cause — Renovate installs 1.26.5, exactly what the `go` directive requires.

## History

Introduced in 8b2cf36 (PR #8, 2026-05-14), whose commit message reads:

> Renovate updated go.mod but didn't tidy, causing CI to fail on the go.sum consistency check. Adds goModTidy to postUpdateOptions so Renovate runs `go mod tidy` automatically on future updates.

That PR fixed its own `go.sum` by hand and added this option to prevent recurrence. The option has been inert ever since, so every Go dependency PR since has needed manual tidying.

## Verification

`renovate-config-validator` accepts **both** spellings, so it cannot confirm this fix — I checked the typo against it directly and it reported `Config validated successfully`. Note it ran in global-config mode; repo-mode validation may behave differently.

The real test is behavioural: after merge, rebase #22 from the Dependency Dashboard and check whether its `go.sum` comes back tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)